### PR TITLE
Extend Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ The following options are available for `docker_systemd::container`:
   * `enable`: Takes any `enable` value accepted by the `Service` resource type
     (Default `true`).
 
+  * `hostname`: The hostname associated with the container.
+
   * `image`: The name of the docker image to use.
+
+  * `privileged`: If set to 'true' give extended privileges to this container.
 
   * `pull_image`: Always pull image before starting the container. (Default
     `false`)

--- a/lib/puppet/parser/functions/build_docker_run_options.rb
+++ b/lib/puppet/parser/functions/build_docker_run_options.rb
@@ -7,6 +7,10 @@ def separate_multi_arg(opt)
   lambda { |args| args.map {|arg| "--#{opt} #{arg}"}.join(' ') }
 end
 
+def toggle_arg(opt)
+  lambda { |arg| "--#{opt}" if arg == 'true' }
+end
+
 module Puppet::Parser::Functions
 
   @@processors = {
@@ -17,6 +21,7 @@ module Puppet::Parser::Functions
     :label_file => single_arg('label-file'),
     :link => separate_multi_arg('link'),
     :name => single_arg('name'),
+    :privileged => toggle_arg('privileged'),
     :publish => separate_multi_arg('publish'),
     :volume => separate_multi_arg('volume'),
     :volumes_from => separate_multi_arg('volumes-from'),

--- a/lib/puppet/parser/functions/build_docker_run_options.rb
+++ b/lib/puppet/parser/functions/build_docker_run_options.rb
@@ -20,6 +20,7 @@ module Puppet::Parser::Functions
     :publish => separate_multi_arg('publish'),
     :volume => separate_multi_arg('volume'),
     :volumes_from => separate_multi_arg('volumes-from'),
+    :hostname => single_arg('hostname')
   }
 
   newfunction(

--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -14,6 +14,7 @@ define docker_systemd::container (
   $env_file         = undef,
   $systemd_env_file = undef,
   $hostname         = undef,
+  $privileged       = undef,
 ) {
 
   include ::docker_systemd
@@ -28,6 +29,7 @@ define docker_systemd::container (
   $docker_run_options = build_docker_run_options({
     link         => $link,
     name         => $title,
+    privileged   => $privileged,
     publish      => $publish,
     volume       => $volume,
     volumes_from => $volumes_from,

--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -13,6 +13,7 @@ define docker_systemd::container (
   $env              = undef,
   $env_file         = undef,
   $systemd_env_file = undef,
+  $hostname         = undef,
 ) {
 
   include ::docker_systemd
@@ -33,7 +34,8 @@ define docker_systemd::container (
     entrypoint   => $entrypoint,
     env          => $env,
     env_file     => $env_file,
-    })
+    hostname     => $hostname,
+  })
 
   file { "/etc/systemd/system/${service_name}":
     ensure  => present,

--- a/manifests/data_volume_container.pp
+++ b/manifests/data_volume_container.pp
@@ -2,6 +2,7 @@ define docker_systemd::data_volume_container (
   $image            = undef,
   $pull_image       = false,
   $systemd_env_file = undef,
+  $volume = undef,
 ) {
 
   include ::docker_systemd
@@ -9,6 +10,7 @@ define docker_systemd::data_volume_container (
   $service_name = "docker-${title}.service"
   $docker_run_options = build_docker_run_options({
     name       => $title,
+    volume     => $volume,
     entrypoint => '/bin/true',
     })
 

--- a/manifests/data_volume_container.pp
+++ b/manifests/data_volume_container.pp
@@ -2,7 +2,8 @@ define docker_systemd::data_volume_container (
   $image            = undef,
   $pull_image       = false,
   $systemd_env_file = undef,
-  $volume = undef,
+  $volume           = undef,
+  $depends          = undef,
 ) {
 
   include ::docker_systemd

--- a/manifests/data_volume_container.pp
+++ b/manifests/data_volume_container.pp
@@ -3,7 +3,7 @@ define docker_systemd::data_volume_container (
   $pull_image       = false,
   $systemd_env_file = undef,
   $volume           = undef,
-  $depends          = undef,
+  $systemd_depends  = undef,
 ) {
 
   include ::docker_systemd

--- a/spec/defines/container_spec.rb
+++ b/spec/defines/container_spec.rb
@@ -66,6 +66,7 @@ EOF
         :env              => ['FOO=BAR', 'BAR=BAZ'],
         :env_file         => ['/etc/foo.list', '/etc/bar.list'],
         :systemd_env_file => '/etc/sysconfig/docker-httpd.env',
+        :hostname     => 'webserver.local',
       }
     }
 
@@ -95,6 +96,7 @@ ExecStart=/usr/bin/docker run --rm \\
     --entrypoint /bin/bash \\
     --env FOO=BAR --env BAR=BAZ \\
     --env-file /etc/foo.list --env-file /etc/bar.list \\
+    --hostname webserver.local \\
     $IMAGE -c $USER_OPTS "/bin/ls"
 ExecStop=/usr/bin/docker stop webserver
 

--- a/spec/defines/container_spec.rb
+++ b/spec/defines/container_spec.rb
@@ -66,7 +66,8 @@ EOF
         :env              => ['FOO=BAR', 'BAR=BAZ'],
         :env_file         => ['/etc/foo.list', '/etc/bar.list'],
         :systemd_env_file => '/etc/sysconfig/docker-httpd.env',
-        :hostname     => 'webserver.local',
+        :privileged       => 'true',
+        :hostname         => 'webserver.local',
       }
     }
 
@@ -90,6 +91,7 @@ ExecStartPre=/usr/bin/docker pull $IMAGE
 ExecStart=/usr/bin/docker run --rm \\
     --link l1:l1 --link l2:l2 \\
     --name webserver \\
+    --privileged \\
     --publish 80:80/tcp \\
     --volume /appdata --volume /shared:/shared:rw \\
     --volumes-from httpd-data \\

--- a/spec/defines/data_volume_container_spec.rb
+++ b/spec/defines/data_volume_container_spec.rb
@@ -6,8 +6,9 @@ describe 'docker_systemd::data_volume_container' do
     let(:title) { 'httpd-data' }
     let(:params) {
       {
-        :image  => 'httpd',
-        :volume => ['/var/data'],
+        :image   => 'httpd',
+        :volume  => ['/var/data'],
+        :depends => ['network.target'],
       }
     }
 
@@ -22,8 +23,8 @@ describe 'docker_systemd::data_volume_container' do
                     'content' => <<-EOF\
 [Unit]
 Description=Docker Data Container for httpd-data
-Requires=docker.service
-After=docker.service
+Requires=docker.service network.target
+After=docker.service network.target
 
 [Service]
 Type=oneshot

--- a/spec/defines/data_volume_container_spec.rb
+++ b/spec/defines/data_volume_container_spec.rb
@@ -8,7 +8,7 @@ describe 'docker_systemd::data_volume_container' do
       {
         :image   => 'httpd',
         :volume  => ['/var/data'],
-        :depends => ['network.target'],
+        :systemd_depends => ['network.target'],
       }
     }
 

--- a/spec/defines/data_volume_container_spec.rb
+++ b/spec/defines/data_volume_container_spec.rb
@@ -6,7 +6,8 @@ describe 'docker_systemd::data_volume_container' do
     let(:title) { 'httpd-data' }
     let(:params) {
       {
-        :image      => 'httpd',
+        :image  => 'httpd',
+        :volume => ['/var/data'],
       }
     }
 
@@ -30,8 +31,9 @@ Restart=no
 RemainAfterExit=yes
 
 
-ExecStart=-/usr/bin/docker run \\
+ExecStart=-/usr/bin/docker create \\
     --name httpd-data \\
+    --volume /var/data \\
     --entrypoint /bin/true \\
     httpd
 ExecStop=/usr/bin/docker stop httpd-data
@@ -80,7 +82,7 @@ Restart=no
 RemainAfterExit=yes
 EnvironmentFile=/etc/sysconfig/docker-httpd-data.env
 ExecStartPre=/usr/bin/docker pull $IMAGE
-ExecStart=-/usr/bin/docker run \\
+ExecStart=-/usr/bin/docker create \\
     --name httpd-data \\
     --entrypoint /bin/true \\
     $IMAGE

--- a/templates/etc/systemd/system/data-container.service.erb
+++ b/templates/etc/systemd/system/data-container.service.erb
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Data Container for <%= @title %>
-Requires=docker.service<% if @depends %><% @depends.each do |dep| %><%= " #{dep}.service" %><% end %><% end %>
-After=docker.service<% if @depends %><% @depends.each do |dep| %><%= " #{dep}.service" %><% end %><% end %>
+Requires=docker.service<% if @depends %><% @depends.each do |dep| %><%= " #{dep}" %><% end %><% end %>
+After=docker.service<% if @depends %><% @depends.each do |dep| %><%= " #{dep}" %><% end %><% end %>
 
 [Service]
 Type=oneshot

--- a/templates/etc/systemd/system/data-container.service.erb
+++ b/templates/etc/systemd/system/data-container.service.erb
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Data Container for <%= @title %>
-Requires=docker.service<% if @depends %><% @depends.each do |dep| %><%= " #{dep}" %><% end %><% end %>
-After=docker.service<% if @depends %><% @depends.each do |dep| %><%= " #{dep}" %><% end %><% end %>
+Requires=docker.service<% if @systemd_depends %><% @systemd_depends.each do |dep| %><%= " #{dep}" %><% end %><% end %>
+After=docker.service<% if @systemd_depends %><% @systemd_depends.each do |dep| %><%= " #{dep}" %><% end %><% end %>
 
 [Service]
 Type=oneshot

--- a/templates/etc/systemd/system/data-container.service.erb
+++ b/templates/etc/systemd/system/data-container.service.erb
@@ -9,7 +9,7 @@ Restart=no
 RemainAfterExit=yes
 <% if @systemd_env_file %><%= "EnvironmentFile=#{@systemd_env_file}" %><% end %>
 <% if @pull_image %>ExecStartPre=/usr/bin/docker pull <%= @image %><% end %>
-ExecStart=-/usr/bin/docker run \
+ExecStart=-/usr/bin/docker create \
     <%= @docker_run_options %> \
     <%= @image %>
 ExecStop=/usr/bin/docker stop <%= @title %>


### PR DESCRIPTION
In this PR I am adding some desirable docker run flags.  These changes should be backwards compatible because the options can be omitted with no ill effect.  I will try to explain the use case for each.
#### feat(container): add hostname param
- This is desirable for many reasons but my current use case is for things like log and data aggregators.  If I am running a datadog container on the host it needs to be passed the hostname of the docker host as the container's default hostname is pretty useless in this situation.
#### feat(data_volume_container): add volume flag
- This is a very useful flag for data volumes if I want to expose a specific path in a data volume container.  If I create a data volume container with a given path(/path/to/data) and then start another container with the volumes-from flag, that container now has the /path/to/data mount without any other parts of the file system contained in the data volume that it may not need.
- I also added a change to the ExecStart to use docker create rather than docker run.  This is in keeping with docker's official documentation for creating data volumes.
#### feat(container): add support for privileged flag
- This one is pretty straightforward.  Unfortunately some very useful containers need to run in privileged mode.
#### feat(data_volume_container): enable depends
- Here we are just pulling functionality that already exists in the docker_systemd::container and it's purpose is pretty much the same here

Thanks for your work and I hope these additions can be useful!
